### PR TITLE
docs: support github light theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-![tinbox logo](https://github.com/gathering/tinbox/blob/main/static/tinbox-white.png?raw=true)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./static/tinbox-white.png">
+  <img alt="tinbox logo" src="./static/tinbox.png">
+</picture>
 
 # tinbox
 


### PR DESCRIPTION
Add support for GitHub light theme as well as dark theme.

![image](https://user-images.githubusercontent.com/10573728/227468793-55f84bc4-bca5-4e87-89a5-9401e34ae024.png) ![image](https://user-images.githubusercontent.com/10573728/227468660-51ac2f89-78b2-4d33-b00d-2a8fa9d834ad.png)